### PR TITLE
If no recipes are to display, show informational message

### DIFF
--- a/cypress/fixtures/index_with_norecipes.json
+++ b/cypress/fixtures/index_with_norecipes.json
@@ -1,3 +1,3 @@
 {
-  "message": "You haven't saved any recipe yet"
+  "recipes": []
 }

--- a/src/components/DisplayRecipeCollection.jsx
+++ b/src/components/DisplayRecipeCollection.jsx
@@ -14,8 +14,8 @@ const DisplayRecipeCollection = () => {
 
   const fetchRecipes = async () => {
     const data = await Recipes.index();
-    if (data.message) {
-      setMessage(data.message);
+    if (data.recipes.length === 0) {
+      setMessage("You haven't saved any recipe yet");
     } else {
       setRecipes(data.recipes);
     }


### PR DESCRIPTION
This PR contains:

- change conditional for getting recipes from api in case when there is no recipes saved.
- change fixture file that returns empty array if no recipes have been saved

[PT story](https://www.pivotaltracker.com/story/show/181688643)