### PR TITLE
Fix spec for conformational message disappearance after deleting a recipe

### DIFF
--- a/cypress/integration/userCanSeeSingleRecipe.feature.js
+++ b/cypress/integration/userCanSeeSingleRecipe.feature.js
@@ -71,7 +71,8 @@ describe("Visiting the application, user", () => {
     });
 
     it("is expected not to see a confirmation message after 3 sek", () => {
-      cy.wait(3000).should("not.exist");
+      cy.wait(3000);
+      cy.get("[data-cy=flash-message]").should("not.exist");
     });
   });
 });


### PR DESCRIPTION
### This PR contains:

- fix spec to check that conformational message is not seen anymore after delting a recipe
[PT story](https://www.pivotaltracker.com/story/show/181945783)