### PR TITLE
Clear image title after successful recipe creation

### DIFF
--- a/cypress/integration/userCanSaveANewRecipe.feature.js
+++ b/cypress/integration/userCanSaveANewRecipe.feature.js
@@ -61,7 +61,7 @@ describe("Visiting the application, a user", () => {
     });
 
     it("is expected not to see image filename anymore", () => {
-      cy.get("[data-cy=filename]").should("not.exist");
+      cy.get("[data-cy=filename]").should("be.empty");
     });
   });
 });

--- a/cypress/integration/userCanSaveANewRecipe.feature.js
+++ b/cypress/integration/userCanSaveANewRecipe.feature.js
@@ -59,5 +59,9 @@ describe("Visiting the application, a user", () => {
         "Recipe was created successfully"
       );
     });
+
+    it("is expected not to see image filename anymore", () => {
+      cy.get("[data-cy=filename]").should("not.exist");
+    });
   });
 });

--- a/src/components/FormToSaveRecipe.jsx
+++ b/src/components/FormToSaveRecipe.jsx
@@ -7,6 +7,7 @@ import { Container, Button } from "@mui/material";
 import { useParams, useNavigate } from "react-router-dom";
 import Headline from "./Headline";
 import ImageInputField from "./ImageInputField";
+import utilities from "../modules/utilities";
 
 const FormToSaveRecipe = () => {
   const navigate = useNavigate();
@@ -18,6 +19,7 @@ const FormToSaveRecipe = () => {
   };
   const [recipe, setRecipe] = useState(initialState);
   const [message, setMessage] = useState();
+  const [fileName, setFileName] = useState("");
   const { id } = useParams();
 
   useEffect(() => {
@@ -39,6 +41,7 @@ const FormToSaveRecipe = () => {
     } else {
       const response = await Recipes.create(recipe);
       setRecipe(initialState);
+      setFileName("");
       setMessage(response.data.message);
     }
   };
@@ -47,6 +50,14 @@ const FormToSaveRecipe = () => {
     setRecipe((previousRecipe) => {
       return { ...previousRecipe, [propName]: value };
     });
+  };
+
+  const handleImage = async (event) => {
+    event.preventDefault();
+    const file = event.target.files[0];
+    file.name && setFileName(file.name);
+    const encodedFile = await utilities.imageEncoder(file);
+    handleChange("image", encodedFile);
   };
 
   return (
@@ -66,7 +77,7 @@ const FormToSaveRecipe = () => {
           instructions={recipe.instructions}
           onInstructionsChange={(value) => handleChange("instructions", value)}
         />
-        <ImageInputField setImage={(value) => handleChange("image", value)} />
+        <ImageInputField fileName={fileName} onImageChange={handleImage} />
         <Button data-cy="save-btn" variant="contained" onClick={saveRecipe}>
           Save
         </Button>

--- a/src/components/ImageInputField.jsx
+++ b/src/components/ImageInputField.jsx
@@ -1,21 +1,12 @@
-import React, { useState } from "react";
+import React from "react";
 import { styled } from "@mui/material/styles";
 import { Button, Typography } from "@mui/material";
-import utilities from "../modules/utilities";
 
-const ImageInputField = ({ setImage }) => {
-  const [fileName, setFileName] = useState("");
+const ImageInputField = ({ onImageChange, fileName }) => {
   const Input = styled("input")({
     display: "none"
   });
 
-  const handleImage = async (event) => {
-    event.preventDefault();
-    const file = event.target.files[0];
-    file.name && setFileName(file.name);
-    const encodedFile = await utilities.imageEncoder(file);
-    setImage(encodedFile);
-  };
   return (
     <div>
       <label htmlFor="contained-button-file">
@@ -23,7 +14,7 @@ const ImageInputField = ({ setImage }) => {
           id="contained-button-file"
           data-cy="attach-image"
           accept="image/*"
-          onChange={handleImage}
+          onChange={onImageChange}
           name="image"
           multiple
           type="file"
@@ -32,7 +23,12 @@ const ImageInputField = ({ setImage }) => {
           Add Image
         </Button>
       </label>
-      <Typography variant="caption" gutterBottom style={{ marginLeft: "10px" }}>
+      <Typography
+        variant="caption"
+        data-cy="filename"
+        gutterBottom
+        style={{ marginLeft: "10px" }}
+      >
         {fileName}
       </Typography>
     </div>


### PR DESCRIPTION
### This PR contains:

- spec that checks for empty filename after successful creation
- setting empty filename after successful recipe creation
- move code to parent component

[PT story](https://www.pivotaltracker.com/story/show/181977392)